### PR TITLE
Show projects grouped by status

### DIFF
--- a/app/Http/Controllers/AcasaController.php
+++ b/app/Http/Controllers/AcasaController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 
 use Carbon\Carbon;
 use App\Models\Proiect;
-use Illuminate\Support\Facades\DB;
 
 class AcasaController extends Controller
 {
@@ -22,16 +21,16 @@ class AcasaController extends Controller
         $proiecteThisMonth  = Proiect::whereDate('data_contract', '>=', $startOfThisMonth)->count();
         $proiecteLastMonth  = Proiect::whereBetween('data_contract', [$startOfLastMonth, $endOfLastMonth])->count();
 
-        // 2. Group projects by stare_contract (status) and get counts for each group
-        $proiecteGroupedByStareContract = Proiect::select('stare_contract', DB::raw('COUNT(*) as total'))
-            ->groupBy('stare_contract')
-            ->get();
+        // 2. Retrieve projects grouped by their status along with the counts
+        $proiecteByStareContract = Proiect::orderBy('stare_contract')
+            ->get()
+            ->groupBy('stare_contract');
 
         return view('acasa', compact(
             'allProiecteCount',
             'proiecteThisMonth',
             'proiecteLastMonth',
-            'proiecteGroupedByStareContract'
+            'proiecteByStareContract'
         ));
     }
 }

--- a/app/Http/Controllers/ProiectController.php
+++ b/app/Http/Controllers/ProiectController.php
@@ -32,6 +32,7 @@ class ProiectController extends Controller
         $searchIntervalDataContract = trim($request->searchIntervalDataContract);
         $searchMembru = trim($request->searchMembru);
         $searchSubcontractant = trim($request->searchSubcontractant);
+        $searchStareContract = trim($request->stare_contract);
 
         $proiecte = Proiect::with('proiectTip', 'membri', 'subcontractanti', 'fisiere', 'emailuriTrimise')
             ->where('proiecte_tipuri_id', $proiectTip->id ?? null)
@@ -55,6 +56,9 @@ class ProiectController extends Controller
                     $q->where('nume', 'LIKE', "%{$searchSubcontractant}%");
                 });
             })
+            ->when($searchStareContract, function ($query, $searchStareContract) {
+                return $query->where('stare_contract', $searchStareContract);
+            })
             ->orderByRaw("
                 CASE
                     WHEN data_proces_verbal_predare_primire IS NULL THEN 0 ELSE 1
@@ -70,7 +74,16 @@ class ProiectController extends Controller
             ")
             ->simplePaginate(25);
 
-        return view('proiecte.index', compact('proiectTip', 'proiecte', 'searchDenumire', 'searchNrContract', 'searchIntervalDataContract', 'searchMembru', 'searchSubcontractant'));
+        return view('proiecte.index', compact(
+            'proiectTip',
+            'proiecte',
+            'searchDenumire',
+            'searchNrContract',
+            'searchIntervalDataContract',
+            'searchMembru',
+            'searchSubcontractant',
+            'searchStareContract'
+        ));
     }
 
     /**

--- a/resources/views/acasa.blade.php
+++ b/resources/views/acasa.blade.php
@@ -1,4 +1,5 @@
 @extends('layouts.app')
+@php use Illuminate\Support\Str; @endphp
 
 @section('content')
 <div class="container">
@@ -40,64 +41,32 @@
             </div>
         </div>
     </div>
-    <div class="row">
-        {{-- <div class="col-md-12 mb-3">
-            <div class="table-responsive rounded">
-                <table class="table table-striped table-hover rounded">
-                    <thead class="text-white rounded">
-                        <tr class="thead-danger" style="padding:2rem">
-                            <th class="text-white culoare2 text-center" colspan="{{ $proiecteGroupedByStareContract->count() }}">Stare proiecte</th>
-                        </tr>
-                        <tr class="thead-danger" style="padding:2rem">
-                            @foreach ($proiecteGroupedByStareContract as $stareContract)
-                                <th class="text-white culoare2 text-center" style="width:{{ 100/$proiecteGroupedByStareContract->count() }}%">
-                                    {{ $stareContract->stare_contract ?? '-'}}
-                                </th>
-                            @endforeach
-                        </tr>
-                    </thead>
-                    <tbody>
-                            @foreach ($proiecteGroupedByStareContract as $stareContract)
-                                <th class="text-white culoare2 text-center">
-                                    <b class="fs-2">{{ $stareContract->total }}</b>
-                                </th>
-                            @endforeach
-                    </tbody>
-                </table>
+    <div class="row justify-content-center">
+        <div class="col-md-8 mb-3">
+            <div class="accordion" id="stareContractAccordion">
+                @foreach($proiecteByStareContract as $stare => $projects)
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="heading-{{ Str::slug($stare ?? 'necunoscut') }}">
+                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ Str::slug($stare ?? 'necunoscut') }}" aria-expanded="false" aria-controls="collapse-{{ Str::slug($stare ?? 'necunoscut') }}">
+                                <span class="me-auto">{{ $stare ?? '-' }}</span>
+                                <span class="badge bg-secondary">{{ $projects->count() }}</span>
+                            </button>
+                        </h2>
+                        <div id="collapse-{{ Str::slug($stare ?? 'necunoscut') }}" class="accordion-collapse collapse" aria-labelledby="heading-{{ Str::slug($stare ?? 'necunoscut') }}" data-bs-parent="#stareContractAccordion">
+                            <div class="accordion-body">
+                                <ul class="mb-2">
+                                    @foreach($projects as $project)
+                                        <li>
+                                            <a href="{{ $project->path() }}">{{ $project->denumire_contract ?? '-' }}</a>
+                                        </li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
             </div>
-        </div> --}}
-
-        <div class="col-md-6 mb-3 text-center mx-auto">
-            <div class="table-responsive rounded">
-                <table class="table table-striped table-hover rounded">
-                    <thead class="text-white rounded">
-                    {{-- Column headers --}}
-                    <tr class="thead-danger" style="padding:2rem">
-                        <th class="text-white culoare2 text-center" style="width:70%">
-                        Stare proiect
-                        </th>
-                        <th class="text-white culoare2 text-center" style="width:30%">
-                        Total
-                        </th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    @foreach($proiecteGroupedByStareContract as $stareContract)
-                        <tr>
-                        <td class="" style="vertical-align:middle">
-                            {{ $stareContract->stare_contract ?? '-' }}
-                        </td>
-                        <td class="text-center">
-                            <b class="">{{ $stareContract->total }}</b>
-                        </td>
-                        </tr>
-                    @endforeach
-                    </tbody>
-                </table>
-                </div>
         </div>
-
-
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- group projects by status in `AcasaController`
- filter projects by `stare_contract` in `ProiectController`
- display groups using an accordion on the home page

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684175c3ce6483269294aee7d2bab0b9